### PR TITLE
TST: run tests in docker image + fix setup.cfg regression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           cd slides
           wget -q https://openslide.cs.cmu.edu/download/openslide-testdata/Aperio/JP2K-33003-1.svs
           cd ..
-          docker run --rm --volume $(pwd):/work --workdir /work wsinfer run \
+          docker run --rm --volume $(pwd):/work --workdir /work wsinferimage run \
             --wsi-dir slides/ --results-dir results/ --model resnet34 --weights TCGA-BRCA-v1
           test -f results/run_metadata.json
           test -f results/patches/JP2K-33003-1.h5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           cd slides
           wget https://openslide.cs.cmu.edu/download/openslide-testdata/Aperio/JP2K-33003-1.svs
           cd ..
-          docker run --rm -it --volume $(pwd):/work --workdir /work wsinfer run \
+          docker run --rm --volume $(pwd):/work --workdir /work wsinfer run \
             --wsi-dir slides/ --results-dir results/ --model resnet34 --weights TCGA-BRCA-v1
           test -f results/run_metadata.json
           test -f results/patches/JP2K-33003-1.h5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,25 @@ jobs:
         run: python -m mypy wsinfer/
       - name: Run tests
         run: python -m pytest --verbose tests/
+  test-docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build Docker image
+        run: docker build -t wsinferimage .
+      - name: Run pytest in Docker image
+        run: |
+          docker run --rm -it --workdir /opt/wsinfer/ --entrypoint bash wsinferimage \
+            -c "python -m pip install -e /opt/wsinfer[dev] && python -m pytest /opt/wsinfer/tests/test_all.py"
+      - name: Run wsinfer on a sample image in Docker
+        run: |
+          mkdir slides
+          cd slides
+          wget https://openslide.cs.cmu.edu/download/openslide-testdata/Aperio/JP2K-33003-1.svs
+          cd ..
+          docker run --rm -it --volume $(pwd):/work --workdir /work wsinfer run \
+            --wsi-dir slides/ --results-dir results/ --model resnet34 --weights TCGA-BRCA-v1
+          test -f results/run_metadata.json
+          test -f results/patches/JP2K-33003-1.h5
+          test -f results/model-outputs/JP2K-33003-1.csv
+          test $(wc -l < results/model-outputs/JP2K-33003-1.csv) -eq 653

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           mkdir slides
           cd slides
-          wget https://openslide.cs.cmu.edu/download/openslide-testdata/Aperio/JP2K-33003-1.svs
+          wget -q https://openslide.cs.cmu.edu/download/openslide-testdata/Aperio/JP2K-33003-1.svs
           cd ..
           docker run --rm --volume $(pwd):/work --workdir /work wsinfer run \
             --wsi-dir slides/ --results-dir results/ --model resnet34 --weights TCGA-BRCA-v1
@@ -68,7 +68,7 @@ jobs:
         run: |
           mkdir newdir && cd newdir
           mkdir slides && cd slides
-          wget https://openslide.cs.cmu.edu/download/openslide-testdata/Aperio/JP2K-33003-1.svs
+          wget -q https://openslide.cs.cmu.edu/download/openslide-testdata/Aperio/JP2K-33003-1.svs
           cd ..
           wsinfer run --wsi-dir slides/ --results-dir results/ --model resnet34 --weights TCGA-BRCA-v1
           test -f results/run_metadata.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         run: docker build -t wsinferimage .
       - name: Run pytest in Docker image
         run: |
-          docker run --rm -it --workdir /opt/wsinfer/ --entrypoint bash wsinferimage \
+          docker run --rm --workdir /opt/wsinfer/ --entrypoint bash wsinferimage \
             -c "python -m pip install -e /opt/wsinfer[dev] && python -m pytest /opt/wsinfer/tests/test_all.py"
       - name: Run wsinfer on a sample image in Docker
         run: |
@@ -47,6 +47,30 @@ jobs:
           cd ..
           docker run --rm --volume $(pwd):/work --workdir /work wsinfer run \
             --wsi-dir slides/ --results-dir results/ --model resnet34 --weights TCGA-BRCA-v1
+          test -f results/run_metadata.json
+          test -f results/patches/JP2K-33003-1.h5
+          test -f results/model-outputs/JP2K-33003-1.csv
+          test $(wc -l < results/model-outputs/JP2K-33003-1.csv) -eq 653
+  test-package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.10
+      - name: Install the package
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install torch torchvision --extra-index-url https://download.pytorch.org/whl/cpu
+          python -m pip install . --find-links https://girder.github.io/large_image_wheels
+      - name: Run the wsinfer command in a new directory
+        run: |
+          mkdir newdir && cd newdir
+          mkdir slides && cd slides
+          wget https://openslide.cs.cmu.edu/download/openslide-testdata/Aperio/JP2K-33003-1.svs
+          cd ..
+          wsinfer run --wsi-dir slides/ --results-dir results/ --model resnet34 --weights TCGA-BRCA-v1
           test -f results/run_metadata.json
           test -f results/patches/JP2K-33003-1.h5
           test -f results/model-outputs/JP2K-33003-1.csv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Install the package
         run: |
           python -m pip install --upgrade pip setuptools wheel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Run pytest in Docker image
         run: |
           docker run --rm --workdir /opt/wsinfer/ --entrypoint bash wsinferimage \
-            -c "python -m pip install -e /opt/wsinfer[dev] && python -m pytest /opt/wsinfer/tests/test_all.py"
+            -c "python -m pip install -e /opt/wsinfer[dev] && python -m pytest -v /opt/wsinfer/tests/test_all.py"
       - name: Run wsinfer on a sample image in Docker
         run: |
           mkdir slides

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,7 +68,7 @@ console_scripts =
 
 [options.package_data]
 wsinfer =
-    patchlib/presets/*.csv
+    _patchlib/presets/*.csv
     modeldefs/*.yaml
 
 [flake8]


### PR DESCRIPTION
Adds a 'test-docker' step to CI. And fixes the path to package_data in setup.cfg.

During the creation of this PR I discovered that the 0.3.2 release wheel will not work because the tcga.csv file is not present (because package_data was not changed when I made patchlib into _patchlib). So after this PR is merged, we should release a new version and remove 0.3.2 from pypi. but the docker images work fine, so we can leave those alone. i added the 'test-package' job in ci to catch regressions in the python package. running wsinfer from a different directory (and from a non-editable install) triggered the error.