### PR TITLE
ENH: add a --speedup option and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,25 @@ jobs:
         run: python -m mypy wsinfer/
       - name: Run tests
         run: python -m pytest --verbose tests/
+  test-pytorch-nightly:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Install the package
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install --pre torch torchvision --extra-index-url https://download.pytorch.org/whl/nightly/cpu
+          python -m pip install --editable .[dev] --find-links https://girder.github.io/large_image_wheels
+      - name: Check style
+        run: python -m flake8 wsinfer/
+      - name: Check types
+        run: python -m mypy wsinfer/
+      - name: Run tests
+        run: python -m pytest --verbose tests/
   test-docker:
     runs-on: ubuntu-latest
     steps:

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -7,7 +7,7 @@ import sys
 from typing import List
 
 from click.testing import CliRunner
-import geojson as geojsoblib
+import geojson as geojsonlib
 import h5py
 import numpy as np
 import pandas as pd
@@ -324,7 +324,7 @@ def test_cli_run_regression(
     result = runner.invoke(cli, ["togeojson", str(results_dir), str(geojson_dir)])
     assert result.exit_code == 0
     with open(geojson_dir / "purple.json") as f:
-        d: geojsoblib.GeoJSON = geojsoblib.load(f)
+        d: geojsonlib.GeoJSON = geojsonlib.load(f)
     assert d.is_valid, "geojson not valid!"
     assert len(d["features"]) == expected_num_patches
 

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -888,10 +888,10 @@ def test_patch_cli(
     for x in range(0, orig_slide_width, expected_patch_size):
         for y in range(0, orig_slide_height, expected_patch_size):
             expected_coords.append([x, y])
-    expected_coords = np.array(expected_coords)
+    expected_coords_arr = np.array(expected_coords)
 
     with h5py.File(savedir / "patches" / f"{stem}.h5") as f:
         assert f["/coords"].attrs["patch_size"] == expected_patch_size
         coords = f["/coords"][()]
     assert coords.shape == (expected_num_patches, 2)
-    assert np.array_equal(expected_coords, coords)
+    assert np.array_equal(expected_coords_arr, coords)

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -258,6 +258,7 @@ def test_cli_run_args(tmp_path: Path):
         ),
     ],
 )
+@pytest.mark.parametrize("speedup", [False, True])
 def test_cli_run_regression(
     model: str,
     weights: str,
@@ -265,6 +266,7 @@ def test_cli_run_regression(
     expected_probs: List[float],
     expected_patch_size: int,
     expected_num_patches: int,
+    speedup: bool,
     tiff_image: Path,
     tmp_path: Path,
 ):
@@ -285,6 +287,7 @@ def test_cli_run_regression(
             weights,
             "--results-dir",
             str(results_dir),
+            "--speedup" if speedup else "--no-speedup",
         ],
     )
     assert result.exit_code == 0

--- a/wsinfer/_modellib/models.py
+++ b/wsinfer/_modellib/models.py
@@ -1,4 +1,5 @@
 import dataclasses
+import functools
 import hashlib
 import os
 from pathlib import Path
@@ -196,6 +197,7 @@ class Weights:
             class_names=d["class_names"],
         )
 
+    @functools.lru_cache(maxsize=1)
     def load_model(self) -> torch.nn.Module:
         """Return the pytorch implementation of the architecture with weights loaded."""
         model = _create_model(name=self.architecture, num_classes=self.num_classes)

--- a/wsinfer/_modellib/models.py
+++ b/wsinfer/_modellib/models.py
@@ -1,5 +1,4 @@
 import dataclasses
-import functools
 import hashlib
 import os
 from pathlib import Path
@@ -218,6 +217,7 @@ class Weights:
             raise RuntimeError("cannot find weights")
 
         model.load_state_dict(state_dict, strict=True)
+        model.eval()
         return model
 
     def get_sha256_of_weights(self) -> str:

--- a/wsinfer/_modellib/models.py
+++ b/wsinfer/_modellib/models.py
@@ -197,7 +197,6 @@ class Weights:
             class_names=d["class_names"],
         )
 
-    @functools.lru_cache(maxsize=1)
     def load_model(self) -> torch.nn.Module:
         """Return the pytorch implementation of the architecture with weights loaded."""
         model = _create_model(name=self.architecture, num_classes=self.num_classes)

--- a/wsinfer/_modellib/run_inference.py
+++ b/wsinfer/_modellib/run_inference.py
@@ -164,7 +164,7 @@ class WholeSlideImagePatches(torch.utils.data.Dataset):
         return patch_im, torch.as_tensor([minx, miny, width, height])
 
 
-def _jit_compile(model: torch.nn.Module):
+def jit_compile(model: torch.nn.Module):
     err = "Warning: could not JIT compile the model. Using non-compiled model instead."
     # TODO: consider freezing the model as well.
     # PyTorch 2.x has torch.compile.
@@ -256,7 +256,7 @@ def run_inference(
     model.to(device)
 
     if speedup:
-        model = _jit_compile(model)
+        model = jit_compile(model)
 
     # results_for_all_slides: typing.List[pd.DataFrame] = []
     for i, (wsi_path, patch_path) in enumerate(zip(wsi_paths, patch_paths)):

--- a/wsinfer/cli/infer.py
+++ b/wsinfer/cli/infer.py
@@ -226,6 +226,12 @@ def _get_info_for_save(weights: models.Weights):
     " for single thread). A reasonable value is 8.",
 )
 @click.option(
+    "--speedup/--no-speedup",
+    default=False,
+    show_default=True,
+    help="JIT-compile the model for potential speedups.",
+)
+@click.option(
     "--dense-grid/--no-dense-grid",
     default=False,
     show_default=True,
@@ -242,6 +248,7 @@ def cli(
     config: typing.Optional[Path],
     batch_size: int,
     num_workers: int = 0,
+    speedup: bool = False,
     dense_grid: bool = False,
 ):
     """Run model inference on a directory of whole slide images.
@@ -321,6 +328,7 @@ def cli(
         weights=weights_obj,
         batch_size=batch_size,
         num_workers=num_workers,
+        speedup=speedup,
     )
 
     run_metadata_outpath = results_dir / "run_metadata.json"


### PR DESCRIPTION
This pr adds a `--speedup` option that jit compiles the model. tests included.

fixes #72 
fixes #70 