### PR TITLE
allow pytest to fail in nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
       - name: Check types
         run: python -m mypy wsinfer/
       - name: Run tests
+        continue-on-error: true
         run: python -m pytest --verbose tests/
   test-docker:
     runs-on: ubuntu-latest


### PR DESCRIPTION
pytorch nightly is a moving target and things may break. we test in nightly to be able to anticipate future breaking changes. but a failure in the nightly tests should not reflect as an overall build failure.