### PR TITLE
[DOCS] fix readthedocs build by adding config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,5 +18,3 @@ python:
       path: .
       extra_requirements:
         - docs
-    - method: pip
-      path: torch torchvision

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,6 +11,11 @@ build:
     post_create_environment:
       - python -m pip install torch torchvision --extra-index-url https://download.pytorch.org/whl/cpu
       - python -m pip install .[docs] --find-links https://girder.github.io/large_image_wheels
+    post_install:
+      # Re-run the installation to ensure we have an appropriate version of sphinx.
+      # We might not want to use the latest version.
+      - python -m pip install .[docs]
+
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,22 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/conf.py
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs
+    - method: pip
+      path: torch torchvision

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,14 +7,11 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.10"
+  jobs:
+    post_create_environment:
+      - python -m pip install torch torchvision --extra-index-url https://download.pytorch.org/whl/cpu
+      - python -m pip install .[docs] --find-links https://girder.github.io/large_image_wheels
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
    configuration: docs/conf.py
-
-python:
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,0 @@
-pydata-sphinx-theme
-sphinx-autoapi
-sphinx-click

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,7 +59,7 @@ dev =
     types-tqdm
 docs =
     pydata-sphinx-theme
-    sphinx
+    sphinx<6.0.0
     sphinx-autoapi
     sphinx-click
 


### PR DESCRIPTION
adds a `.readthedocs.yaml` config file.